### PR TITLE
Add content changes for supporting both rST and Markdown in Sphinx

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,6 @@ If you want to go beyond just creating a markdown file, you will need to install
 4. Sphinx - This will build our tutorials into HTML and other formats (this uses the Python package installer 'pip' so Python must be installed first); we will also install the theme we need for our documentation
         
         $ pip install sphinx sphinx-autobuild sphinx_rtd_theme
-5. Pandoc - This will convert Markdown into ReStructured text
-    - http://pandoc.org/installing.html
 6. RestView - Optional, but makes it easy to preview ReStructured text files [http://rst.ninjs.org/](http://rst.ninjs.org/) or install:
 
         $ pip install restview 
@@ -92,29 +90,17 @@ If you want to go beyond just creating a markdown file, you will need to install
     - The CyVerse base tutorial repo URL is **https://github.com/CyVerse-learning-materials/cyverse_base_tutorial_repo**
     - Name your repo for the name of your quick start or tutorial, e.g. 
     *'name_quickstart'* or *'name_tutorial'*
-2. Edit the **markdown version** of the template you are working from. Save images or other files in the appropriate directories. 
+2. Edit the **markdown version** of the template you are working from. Save images or other files in the appropriate directories.
 3. Delete unused templates. We will have **only one tutorial or quick start per repo.**
-4. Save your markdown as  *'name_quickstart.md'* or *'name_tutorial.md'*
-5. In the repo directory start the process of building the tutorial files:
-        
-        $ sphinx-quickstart --project='title_of_your_tutorial_or_quick_start' --author="your_name" -v=1.0
-        # you may accept most defaults (by hitting enter)
-      
-6. Convert the markdown file to ReStructured text file (which we will call *index.rst*) using Pandoc:
-
-        $ pandoc -f markdown -t rst -o index.rst your_file_name.md    
-
-    For convenience, the templates have a few ReStructured text elements that may not be properly converted by Pandoc. You will need to check the converted ReStructured text. You can use an online viewer [http://rst.ninjs.org/](http://rst.ninjs.org/) or you can view live changes using restview. 
-7. You may need to edit the *'conf.py'* file to change the following values:
-     - copyright = 'YEAR, CyVerse'
-     - html_theme = 'sphinx_rtd_theme'
-   We have provided a sample  *'conf.py'* file in the */misc* folder which you could also edit and replace.    
-8. Build the tutorial:
+4. Save your markdown as  *'index.md'*
+5. Edit the *'conf.py'* file to set the project and author information
+6. Build the tutorial:
 
         $ make html
-9. Your HTML site will be in the _build directory that has been created. 
-10. Commit your changes and push the tutorial back to GitHub.
-11. Notify [Tutorials@CyVerse.org](mailto:Tutorials@CyVerse.org) that your tutorial is ready for inclusion in the main CyVerse documentation repo. We will review and verify the contribution, and add you as a maintainer repo in the CyVerse collection. You should make future edits following the instructions above for 'Fixing and/or improving documentation via GitHub.' Alternatively, you can host your tutorial independently on ReadTheDocs following their [instructions for importing documentation](https://docs.readthedocs.io/en/latest/getting_started.html#import-your-docs). 
+
+7. Your HTML site will be in the _build directory that has been created.
+8. Commit your changes and push the tutorial back to GitHub.
+9. Notify [Tutorials@CyVerse.org](mailto:Tutorials@CyVerse.org) that your tutorial is ready for inclusion in the main CyVerse documentation repo. We will review and verify the contribution, and add you as a maintainer repo in the CyVerse collection. You should make future edits following the instructions above for 'Fixing and/or improving documentation via GitHub.' Alternatively, you can host your tutorial independently on ReadTheDocs following their [instructions for importing documentation](https://docs.readthedocs.io/en/latest/getting_started.html#import-your-docs).
 
 
 ## Other tutorial elements

--- a/index.md
+++ b/index.md
@@ -1,0 +1,140 @@
+<!---
+
+Images can be added in-line as a reStructured text substitution, but will not render in markdown. See reStructured text example. http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#substitution-definitions
+
+|CyVerse logo|
+
+--->
+
+#Quick Start name
+<!---
+Use short, imperative titles e.g. Upload and share data, uploading and sharing data
+--->
+
+## Goal
+
+<!---
+Avoid covering upstream and downstream steps that are not explicitly and necessarily part of the tutorial - write or link to separate quick starts/tutorials for those parts
+--->
+
+<!---
+A few sentences (50 words or less) describing the ultimate goal of the steps in this tutorial
+--->
+
+## Prerequisites 
+
+
+### Downloads, access, and services
+
+*In order to complete this tutorial you will need access to the following services/software*
+
+```eval_rst
+.. list-table::
+    :header-rows: 1
+
+    * - Prerequisite
+      - Preparation/Notes
+      - Link/Download
+    * - CyVerse account
+      - You will need a CyVerse account to complete this exercise
+      - `Register <https://user.cyverse.org/>`_
+    * - Atmosphere access
+      - You must have access to Atmosphere
+      - `Request Access <http://www.cyverse.org/learning-center/manage-account#AddAppsServices>`_
+    * - Cyberduck
+      - Standalone software for upload/download to Data Store
+      - `Download <https://cyberduck.io/>`_
+```
+
+### Platform(s)
+
+*We will use the following CyVerse platform(s):*
+
+|Platform|Interface|Link|Platform Documentation|Quick Start|
+|--------|---------|----|----------------------|-----------|
+|Discovery Environment|Web/Point-and-click|[Discovery Environment](https://de.iplantcollaborative.org)|[Manual](https://wiki.cyverse.org/wiki/display/DEmanual/Table+of+Contents)|[Quick Start]()
+|Atmosphere|Command-line (ssh) and/or Desktop (VNC)|[Atmosphere](https://atmo.cyverse.org)|[Manual](https://wiki.cyverse.org/wiki/display/atmman/Atmosphere+Manual+Table+of+Contents)|[Quick Start]()|
+|BisQue|Web/Point-and-click and/or Command-line (API)|[BisQue](http://bisque.iplantcollaborative.org/client_service)|[Manual](https://wiki.cyverse.org/wiki/display/BIS)|[Quick Start]()|
+|DNA Subway|Web/Point-and-click|[DNA Subway](http://dnasubway.iplantcollaborative.org/)|[Manual](http://dnasubway.iplantcollaborative.org/files/pdf/DNA_Subway_Guide.pdf)|[Quick Start]()|
+|Agave API|Command-line (API)|[Agave API](https://agaveapi.co)|[Live Docs](https://agaveapi.co)|[Quick Start]()|
+
+### Input and example data
+
+*In order to complete this tutorial you will need to have the following inputs prepared*
+
+|Input File(s)|Format|Preparation/Notes|Example Data|
+|-------------|------|-----------------|------------|
+||||
+
+
+---
+
+## Get started
+
+<!---
+Steps and text go here
+--->
+
+
+<!---
+.. Hint::
+	You can insert reStructured text directives in the Markdown. The formatting will have to be fixed later in the .rst document see [rst docs](http://docutils.sourceforge.net/docs/ref/rst/directives.html#admonitions)
+--->
+
+### Summary
+
+<!---
+Summary a--->
+
+**Next Steps:**
+
+
+## More help and additional information
+
+<!---
+Short description and links to any reading materials
+--->
+
+- **Search for an answer:** [CyVerse Learning Center](http://www.cyverse.org/learning-center) or [CyVerse Wiki](https://wiki.cyverse.org)
+- **Post your question to the user forum:** [Ask CyVerse](http://ask.iplantcollaborative.org/questions)
+
+### Fix or improve this tutorial 
+
+- **Fix this tutorial on GitHub:** [GitHub](FIX_THIS_IN_YOUR_DOCUMENTATION)
+- **Send a note:** [Tutorials@CyVerse.org](mailto:Tutorials@CyVerse.org)
+
+<!---
+
+SAMPLE DIRECTIVES (DELETE UNUSED ONES)
+--------------------------------------
+
+See: http://docutils.sourceforge.net/docs/ref/rst/directives.html#admonitions
+
+.. Danger::
+	This step is dangerous
+
+.. Important::
+	This step is important
+	
+.. Caution::
+	Exercise caution
+	
+.. Hint::
+	This is a hint
+
+.. Important::
+	This is very important
+
+.. note:: This is a note admonition.
+   This is the second line of the first paragraph.
+
+   - The note contains all indented body elements
+     following.
+   - It includes this bullet list.
+
+
+
+.. |CyVerse logo| image:: ./img/cyverse_rgb.png
+    :width: 500
+    :height: 100
+--->

--- a/index.rst
+++ b/index.rst
@@ -1,0 +1,175 @@
+|CyVerse logo|
+
+PROJECT NAME
+============
+
+..
+    Use short, imperative titles e.g. Upload and share data, uploading and
+    sharing data
+
+Goal
+----
+
+..
+    Avoid covering upstream and downstream steps that are not explicitly and
+    necessarily part of the tutorial - write or link to separate quick
+    starts/tutorials for those parts
+
+
+Prerequisites
+-------------
+
+..
+    A few sentences (50 words or less) describing the ultimate goal of the steps
+    in this tutorial
+
+
+Downloads, access, and services
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+*In order to complete this tutorial you will need access to the following services/software*
+
+.. list-table::
+    :header-rows: 1
+
+    * - Prerequisite
+      - Preparation/Notes
+      - Link/Download
+    * - CyVerse account
+      - You will need a CyVerse account to complete this exercise
+      - `Register <https://user.cyverse.org/>`_
+    * - Atmosphere access
+      - You must have access to Atmosphere
+      - `Request Access <http://www.cyverse.org/learning-center/manage-account#AddAppsServices>`_
+    * - Cyberduck
+      - Standalone software for upload/download to Data Store
+      - `Download <https://cyberduck.io/>`_
+
+Platform(s)
+~~~~~~~~~~~
+
+*We will use the following CyVerse platform(s):*
+
+.. list-table::
+    :header-rows: 1
+
+    * - Platform
+      - Interface
+      - Link
+      - Platform Documentation
+      - Quick Start
+    * - Discovery Environment
+      - Web/Point-and-click
+      - `Discovery Environment <https://de.iplantcollaborative.org>`_
+      - `Manual <https://wiki.cyverse.org/wiki/display/DEmanual/Table+of+Contents>`_
+      - `Quick Start <>`_
+    * - Atmosphere
+      - Command-line (ssh) and/or Desktop (VNC)
+      - `Atmosphere <https://atmo.cyverse.org>`_
+      - `Manual <https://wiki.cyverse.org/wiki/display/atmman/Atmosphere+Manual+Table+of+Contents>`_
+      - `Quick Start <>`_
+    * - BisQue
+      - Web/Point-and-click and/or Command-line (API)
+      - `BisQue <http://bisque.iplantcollaborative.org/client_service>`_
+      - `Manual <https://wiki.cyverse.org/wiki/display/BIS>`_
+      - `Quick Start <>`_
+    * - DNA Subway
+      - Web/Point-and-click
+      - `DNA Subway <http://dnasubway.iplantcollaborative.org/>`_
+      - `Manual <http://dnasubway.iplantcollaborative.org/files/pdf/DNA_Subway_Guide.pdf>`_
+      - `Quick Start <>`_
+    * - Agave API
+      - Command-line (API)
+      - `Agave API <https://agaveapi.co>`_
+      - `Live Docs <https://agaveapi.co>`_
+      - `Quick Start <>`_
+
+Input and example data
+~~~~~~~~~~~~~~~~~~~~~~
+
+*In order to complete this tutorial you will need to have the following inputs prepared*
+
+.. list-table::
+    :header_rows: 1
+
+    * - Input File(s)
+      - Format
+      - Preparation/Notes
+      - Example Data
+
+---
+
+Get started
+-----------
+
+..
+    Steps and text go here
+
+Summary
+~~~~~~~
+
+..
+    Summary
+
+**Next Steps:**
+
+
+More help and additional information
+------------------------------------
+
+..
+    Short description and links to any reading materials
+
+Search for an answer:
+    `CyVerse Learning Center <http://www.cyverse.org/learning-center>`_ or
+    `CyVerse Wiki <https://wiki.cyverse.org>`_
+
+Post your question to the user forum:
+    `Ask CyVerse <http://ask.iplantcollaborative.org/questions>`_
+
+Fix or improve this tutorial
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Fix this tutorial on GitHub:
+    `GitHub <FIX_THIS_IN_YOUR_DOCUMENTATION>`_
+
+Send a note:
+    `Tutorials@CyVerse.org <Tutorials@CyVerse.org>`_
+
+..
+    Example rST Directives
+    ----------------------
+    
+    See: http://docutils.sourceforge.net/docs/ref/rst/directives.html#admonitions
+    
+    .. Danger::
+        This step is dangerous
+    
+    .. Important::
+        This step is important
+    
+    .. Caution::
+        Exercise caution
+    
+    .. Hint::
+        This is a hint
+    
+    .. Important::
+        This is very important
+    
+    .. note:: This is a note admonition.
+       This is the second line of the first paragraph.
+    
+       - The note contains all indented body elements following.
+       - It includes this bullet list.
+    
+    .. csv-table:: Title
+        :header: "Column A", "Column B", "Column C"
+        :widths: 15, 10, 30
+        
+        "A", "B", "C"
+
+
+.. |CyVerse logo| image:: ./img/cyverse_rgb.png
+    :width: 500
+    :height: 100


### PR DESCRIPTION
* Adds an `index.rst`. This file has secondary preference to `index.md` and
  won't render by default in this repository
* Adds an example `index.md` that has some of the changes you might see if
  trying to use tables through Markdown -> rST

Because CommonMark doesn't support tables, we must rely on rST for these
constructs. rST has much better support for table authoring, such as the
`list-table` and `csv-table` directives. This doesn't require hand manipulation
of table boundaries.

An option here is to remove tables from the contant, and then the default
markdown experience will work great. You will still have the ability to author
tables using the `eval_rst` transform in `index.md` now.

Eventually, recommonmark and CommonMark will support a form of tables, likely
close to the GitHub flavored markdown table spec.

This PR relies on #11, I separated the content changes, as this PR doesn't necessarily have to be merged. This PR can be used as an example.